### PR TITLE
feature/SMART_ROUTE_CACHING | changed method call in HandlePageUrls.php

### DIFF
--- a/src/Models/Concerns/HandlesPageUrls.php
+++ b/src/Models/Concerns/HandlesPageUrls.php
@@ -67,6 +67,6 @@ trait HandlesPageUrls {
      * @return string[]
      */
     public function getAllUrls(): array {
-        return array_map([$this, 'getUrl'], $this->getAllUrlCacheKeysArgs());
+        return array_map([$this, 'getUrl'], $this->getAllCacheKeyArgs());
     }
 }


### PR DESCRIPTION
Changes the method call inside HandlePageUrls.php in getAllUrls() 
from `$this->getAllUrlCacheKeysArgs()`
to `$this->getAllCacheKeyArgs()`
